### PR TITLE
Patch File Load Macro to Use Work Directory

### DIFF
--- a/STAT6250-02_s17-team-0_project1_data_preparation.sas
+++ b/STAT6250-02_s17-team-0_project1_data_preparation.sas
@@ -62,7 +62,7 @@ https://github.com/stat6250/team-0_project1/blob/master/frpm1516-edited.xls?raw=
     %then
         %do;
             %put Loading dataset &dsn. over the wire now...;
-            filename tempfile TEMP;
+            filename tempfile "%sysfunc(getoption(work))/tempfile.xlsx";
             proc http
                 method="get"
                 url="&url."


### PR DESCRIPTION
Switch from a SAS-managed temp file to a file stored in the directory for the Work library, in order to avoid path issues that affect some .xlsx files.